### PR TITLE
fixed authorized_keys file name for admin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Use the private key for the SSH command and copy the public key to the `authoriz
 For Windows there are two different ways to achieve successful login by public key authentication
 
 1. For a regular user, add the public key to `C:/Users/<user>/.ssh/authorized_keys`
-1. For a user in the Administrator group, add the public key to `%ProgramData%/ssh/authorized_keys`
+1. For a user in the Administrator group, add the public key to `%ProgramData%/ssh/administrators_authorized_keys`
    The folder is the working space for OpenSSH and you need administrative access rights
 
 See working examples for this in the Test section below,
@@ -109,7 +109,7 @@ connect from any machine and try some scenarios:
   scp {rsync,d2u,u2d}.exe <user>@<windows-host>:C:/Windows/system32/OpenSSH
   scp cyg* <user>@<windows-host>:C:/Windows/system32/OpenSSH
   ```
-- Use Rsync locally on windows with some specific options
+- Use Rsync locally on windows with some specific options:
   ```
   rsync -r -v --size-only --chmod=ugo=rwX "D:/projects" "E:/backup"
   ```


### PR DESCRIPTION
For Windows users in the Administrator group the name of the authorized_keys file must be administrators_authorized_keys in the %PROGRAMDATA%/ssh folder.